### PR TITLE
Add overlay controls to speak selection

### DIFF
--- a/StudentHelper/background.js
+++ b/StudentHelper/background.js
@@ -1,13 +1,6 @@
 chrome.action.onClicked.addListener((tab) => {
-    chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      function: () => {
-        const text = window.getSelection().toString();
-        if (text) {
-          const utterance = new SpeechSynthesisUtterance(text);
-          speechSynthesis.speak(utterance);
-        }
-      }
-    });
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    files: ['overlay.js']
   });
-  
+});

--- a/StudentHelper/manifest.json
+++ b/StudentHelper/manifest.json
@@ -1,10 +1,9 @@
 {
-    "manifest_version": 3,
-    "name": "Simple TTS",
-    "description": "Reads selected text aloud",
-    "version": "1.0",
-    "permissions": ["activeTab", "scripting"],   // add "scripting"
-    "action": { "default_title": "Speak selection" },
-    "background": { "service_worker": "background.js" }
-  }
-  
+  "manifest_version": 3,
+  "name": "Simple TTS",
+  "description": "Reads selected text aloud",
+  "version": "1.0",
+  "permissions": ["activeTab", "scripting"],
+  "action": { "default_title": "Speak selection" },
+  "background": { "service_worker": "background.js" }
+}

--- a/StudentHelper/overlay.js
+++ b/StudentHelper/overlay.js
@@ -1,0 +1,70 @@
+(function() {
+  // Remove existing overlay if any
+  const existing = document.getElementById('simple-tts-overlay');
+  if (existing) {
+    existing.remove();
+  }
+
+  // Create overlay container
+  const overlay = document.createElement('div');
+  overlay.id = 'simple-tts-overlay';
+  Object.assign(overlay.style, {
+    position: 'fixed',
+    bottom: '20px',
+    right: '20px',
+    padding: '10px',
+    background: 'white',
+    border: '1px solid #ccc',
+    zIndex: 9999,
+    boxShadow: '0 2px 6px rgba(0,0,0,0.3)',
+    borderRadius: '4px',
+    fontFamily: 'sans-serif'
+  });
+
+  const playPauseBtn = document.createElement('button');
+  playPauseBtn.textContent = 'Play';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'X';
+  closeBtn.style.marginLeft = '8px';
+
+  overlay.appendChild(playPauseBtn);
+  overlay.appendChild(closeBtn);
+  document.body.appendChild(overlay);
+
+  let utterance = null;
+
+  playPauseBtn.addEventListener('click', () => {
+    if (speechSynthesis.speaking && !speechSynthesis.paused) {
+      // Pause currently playing utterance
+      speechSynthesis.pause();
+      playPauseBtn.textContent = 'Resume';
+      return;
+    }
+
+    if (speechSynthesis.paused) {
+      // Resume paused speech
+      speechSynthesis.resume();
+      playPauseBtn.textContent = 'Pause';
+      return;
+    }
+
+    // Start speaking selected text
+    const text = window.getSelection().toString().trim();
+    if (!text) {
+      alert('Please select text to read.');
+      return;
+    }
+    utterance = new SpeechSynthesisUtterance(text);
+    utterance.onend = () => {
+      playPauseBtn.textContent = 'Play';
+    };
+    speechSynthesis.speak(utterance);
+    playPauseBtn.textContent = 'Pause';
+  });
+
+  closeBtn.addEventListener('click', () => {
+    speechSynthesis.cancel();
+    overlay.remove();
+  });
+})();


### PR DESCRIPTION
## Summary
- revise `overlay.js` so that the Play button speaks the current selection and toggles pause/resume
- keep a floating overlay with play/pause and close controls injected by the background script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684083b35df88328bcf2e95ef2e5d77f